### PR TITLE
Spencer/mob 199 basic markdown support 5

### DIFF
--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -57,7 +57,7 @@ export default class RichTextEditor extends Component {
       initialFocus,
       disabled,
       styleWithCSS,
-      useCharacter
+      useCharacter,
       defaultHttps,
     } = props;
     that.state = {

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -271,7 +271,7 @@ export default class RichTextEditor extends Component {
           ref={that.setRef}
           onMessage={that.onMessage}
           originWhitelist={['*']}
-          dataDetectorTypes={['none']}
+          dataDetectorTypes={'none'}
           domStorageEnabled={false}
           bounces={false}
           javaScriptEnabled={true}

--- a/src/editor.js
+++ b/src/editor.js
@@ -342,7 +342,7 @@ function createHTML(options = {}) {
                 function(match, boldItalic, biContent, bold, bContent, italic, iContent, strike, sContent) {
                     if (boldItalic) {
                         return '<span class="markdown-tag">' + boldItalic + '</span>' +
-                                '<b><i>' + biContent + '</b></i>' +
+                                '<b><i>' + biContent + '</i></b>' +
                                 '<span class="markdown-tag">' + boldItalic + '</span>';
                     } else if (bold) {
                         return '<span class="markdown-tag">' + bold + '</span>' +

--- a/src/editor.js
+++ b/src/editor.js
@@ -62,8 +62,8 @@ function createHTML(options = {}) {
         .pell { height: 100%;} .pell-content { outline: 0; overflow-y: auto;padding: 10px;height: 100%;${contentCSSText}}
     </style>
     <style>
-        [placeholder]:empty:before { content: attr(placeholder); color: ${placeholderColor};}
-        [placeholder]:empty:focus:before { content: attr(placeholder);color: ${placeholderColor};display:block;}
+        [placeholder]:empty:before { content: attr(placeholder); color: ${placeholderColor}; font-size: 16px;}
+        [placeholder]:empty:focus:before { content: attr(placeholder);color: ${placeholderColor};display:block; font-size: 16px;}
     </style>
     ${getContentCSS()}
     <style>${cssText}</style>

--- a/src/editor.js
+++ b/src/editor.js
@@ -313,6 +313,9 @@ function createHTML(options = {}) {
             return didChange;
         }
 
+        function applyMarkdownSyntax(syntax) {
+            return '<span class="markdown-tag">' + syntax + '</span>'
+        }
         function styleAndPreserveMarkdown() {
             const div = editor.content;
             const selection = window.getSelection();
@@ -341,21 +344,21 @@ function createHTML(options = {}) {
                 /(\\*\\*\\*|___)(?!\\1)(.*?)\\1|(\\*\\*|__)(?!\\3)(.*?)\\3|(\\*|_)(?!\\5)(.*?)\\5|(~~)(?!\\7)(.*?)\\7/g,
                 function(match, boldItalic, biContent, bold, bContent, italic, iContent, strike, sContent) {
                     if (boldItalic) {
-                        return '<span class="markdown-tag">' + boldItalic + '</span>' +
+                        return applyMarkdownSyntax(boldItalic) +
                                 '<b><i>' + biContent + '</i></b>' +
-                                '<span class="markdown-tag">' + boldItalic + '</span>';
+                                applyMarkdownSyntax(boldItalic);
                     } else if (bold) {
-                        return '<span class="markdown-tag">' + bold + '</span>' +
+                        return applyMarkdownSyntax(bold) +
                                 '<b>' + bContent + '</b>' +
-                                '<span class="markdown-tag">' + bold + '</span>';
+                                applyMarkdownSyntax(bold);
                     } else if (italic) {
-                        return '<span class="markdown-tag">' + italic + '</span>' +
+                        return applyMarkdownSyntax(italic) +
                                 '<i>' + iContent + '<i>' +
-                                '<span class="markdown-tag">' + italic + '</span>';
+                                applyMarkdownSyntax(italic);
                     } else if (strike) {
-                        return '<span class="markdown-tag">' + strike + '</span>' +
+                        return applyMarkdownSyntax(strike) +
                                 '<span style="text-decoration: line-through;">' + sContent + '</span>' +
-                                '<span class="markdown-tag">' + strike + '</span>';
+                                applyMarkdownSyntax(strike);
                     }
                     return match;
                 }

--- a/src/editor.js
+++ b/src/editor.js
@@ -327,22 +327,17 @@ function createHTML(options = {}) {
                 cursorOffset = preRange.toString().length;
             }
 
-            const editorHTML = div.innerHTML;
+            let editorHTML = div.innerHTML;
             console.debug("starting html", editorHTML);
 
-            // Create a temporary div to operate on
-            const tempRoot = document.createElement("div");
-            tempRoot.innerHTML = editorHTML;
-
             // Flatten all elements leaving only allowed <div>, <br>, and text nodes
-            stripHTMLAndFlatten(tempRoot);
+            stripHTMLAndFlatten(editorHTML);
 
             // Convert it to a string for the markdown parsing.
-            const flattenedHTML = tempRoot.innerHTML;
-            console.debug("flattened HTML:", flattenedHTML)
+            console.debug("flattened HTML:", editorHTML)
 
             // Apply styling and preserve markdown
-            const parsedHTML = flattenedHTML.replace(
+            editorHTML = editorHTML.replace(
                 /(\\*\\*\\*|___)(?!\\1)(.*?)\\1|(\\*\\*|__)(?!\\3)(.*?)\\3|(\\*|_)(?!\\5)(.*?)\\5|(~~)(?!\\7)(.*?)\\7/g,
                 function(match, boldItalic, biContent, bold, bContent, italic, iContent, strike, sContent) {
                     if (boldItalic) {
@@ -366,8 +361,8 @@ function createHTML(options = {}) {
                 }
             );
 
-            div.innerHTML = parsedHTML;
-            console.debug('parsed HTML', parsedHTML)
+            console.debug('parsed HTML', editorHTML)
+            div.innerHTML = editorHTML;
 
             // Restore cursor position
             const walker = document.createTreeWalker(div, NodeFilter.SHOW_TEXT, null, false);

--- a/src/editor.js
+++ b/src/editor.js
@@ -328,7 +328,7 @@ function createHTML(options = {}) {
         */
         function parseMarkdown() {
             const editorContent = editor.content;
-            
+        
             // Save the active cursor position. We'll restore it after parsing.
             // Note - the rangeCount of an idle cursor is 1. A rangeCount of 0 means no cursor is active in the editor.
             const selection = window.getSelection();        
@@ -336,13 +336,13 @@ function createHTML(options = {}) {
             let cursorOffset = 0;
             if (range) {
                 const preRange = document.createRange();
-                preRange.setStart(div, 0);
+                preRange.setStart(editorContent, 0);
                 preRange.setEnd(range.startContainer, range.startOffset);
                 cursorOffset = preRange.toString().length;
             }
-
+                
             // Get editor html. User input is escaped at this point.
-            const editorHTML = div.innerHTML;
+            const editorHTML = editorContent.innerHTML;
             console.debug("starting html", editorHTML);
 
             // Create a temporary div to operate on
@@ -381,11 +381,11 @@ function createHTML(options = {}) {
             console.debug('parsed HTML', parsedHTML)
 
             // Replace editor content with parsed HTML
-            div.innerHTML = parsedHTML;
+            editorContent.innerHTML = parsedHTML;
 
             // Restore cursor position.
             // We do so using our existing cursor offset.
-            const walker = document.createTreeWalker(div, NodeFilter.SHOW_TEXT, null, false);
+            const walker = document.createTreeWalker(editorContent, NodeFilter.SHOW_TEXT, null, false);
             let currentOffset = 0;
             let found = false;
             let node;
@@ -413,7 +413,7 @@ function createHTML(options = {}) {
             // collapse the selection at the end of the content and place cursor at the end.
             if (range) {
                 if (!found) {
-                    range.selectNodeContents(div);
+                    range.selectNodeContents(editorContent);
                     range.collapse(false);
                 }
             }

--- a/src/editor.js
+++ b/src/editor.js
@@ -856,7 +856,6 @@ function createHTML(options = {}) {
                 clearTimeout(_handleCTime);
                 _handleCTime = setTimeout(function(){
                     var html = Actions.content.getHtml();
-                      console.debug('CONTENT_CHANGE html', html)
                     postAction({type: 'CONTENT_CHANGE', data: html});
                 }, 50);
             }

--- a/src/editor.js
+++ b/src/editor.js
@@ -276,7 +276,7 @@ function createHTML(options = {}) {
         }
 
         /*
-        * Strip and flatten markup to start with a clean slate for markdown parsing
+        * Strip and flatten markup to start with clean text for markdown parsing
         */
         function stripHTMLAndFlatten(element) {
             let changed = true;
@@ -341,7 +341,7 @@ function createHTML(options = {}) {
                 cursorOffset = preRange.toString().length;
             }
 
-            // Get editor html
+            // Get editor html. User input is escaped at this point.
             const editorHTML = div.innerHTML;
             console.debug("starting html", editorHTML);
 


### PR DESCRIPTION
# Overview
This PR introduces live markdown parsing to the react native rich editor package. Parsing occurs on the onInput listener event.

[react native rich editor ](https://github.com/wxik/react-native-rich-editor/issues?q=is%3Aissue%20state%3Aopen%20keyboard) is a React Native component wrapper around a [contenteditable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable) div through a webview. The package comes with several actions and listeners that enable inserting styled html elements for actions like bolding, italicizing, etc. We're adding our own markdown parsing in javascript to the web view source for our use case.

Parsing occurs on input events, where we receive and html version of the current user input. We modify the contenteditable html and apply styling in the form of spans and other appropriate elements. Important considerations through this logic here was handling the cursor position and line breaks. For now, I've tried to leave what I can do be handled by default contenteditable and editor behavior.