### PR TITLE
Spencer/mob 199 basic markdown support 6

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -231,8 +231,9 @@ export type IconRecord = {
   iconSize: number;
 };
 export type SelectionChangeListener = (items: (string | {type: string; value: string})[]) => void;
-export type CursorContext =  { type: 'cursor'; data: { decorators: {bold: boolean; italic: boolean } } }
-export type CursorContextListener = (items: { type: 'cursor'; data: CursorContext }) => void;
+
+export type CursorContext =  {  type: 'cursor'; decorators: { bold: boolean; italic: boolean; strikeThrough: boolean } }
+export type CursorContextListener = (items: CursorContext) => void;
 export declare class RichEditor extends React.Component<RichEditorProps> {
   // Public API
 
@@ -243,7 +244,7 @@ export declare class RichEditor extends React.Component<RichEditorProps> {
 
   registerToolbar: (listener: SelectionChangeListener) => void;
 
-  subscribeToCursorContext: (listener: SelectionChangeListener) => void;
+  subscribeToCursorContext: (listener: CursorContextListener) => void;
 
   /**
    * @deprecated please use onFocus

--- a/index.d.ts
+++ b/index.d.ts
@@ -230,7 +230,9 @@ export type IconRecord = {
   tintColor: any;
   iconSize: number;
 };
-
+export type SelectionChangeListener = (items: (string | {type: string; value: string})[]) => void;
+export type CursorContext =  { type: 'cursor'; data: { decorators: {bold: boolean; italic: boolean } } }
+export type CursorContextListener = (items: { type: 'cursor'; data: CursorContext }) => void;
 export declare class RichEditor extends React.Component<RichEditorProps> {
   // Public API
 
@@ -240,6 +242,8 @@ export declare class RichEditor extends React.Component<RichEditorProps> {
   getContentHtml: () => Promise<string>;
 
   registerToolbar: (listener: SelectionChangeListener) => void;
+
+  subscribeToCursorContext: (listener: SelectionChangeListener) => void;
 
   /**
    * @deprecated please use onFocus

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -166,11 +166,9 @@ export default class RichTextEditor extends Component {
           onLink?.(data);
           break;
         case messages.LOG:
-          console.log('FROM EDIT:', ...data);
           break;
         case messages.SELECTION_CHANGE:
           // fire the cursor context listener with data from the message
-          console.log('SELECTION_CHANGE', data);
           if (data.type === 'cursor') {
             that.cursorContextListeners.map(listener => {
               listener(data);

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -29,6 +29,7 @@ export default class RichTextEditor extends Component {
     that.onMessage = that.onMessage.bind(that);
     that.sendAction = that.sendAction.bind(that);
     that.registerToolbar = that.registerToolbar.bind(that);
+    that.cursorContext = that.subscribeToCursorContext.bind(that);
     that._onKeyboardWillShow = that._onKeyboardWillShow.bind(that);
     that._onKeyboardWillHide = that._onKeyboardWillHide.bind(that);
     that.init = that.init.bind(that);
@@ -39,6 +40,7 @@ export default class RichTextEditor extends Component {
     that._focus = false;
     that.layout = {};
     that.selectionChangeListeners = [];
+    that.cursorContextListeners = []
     const {
       editorStyle: {backgroundColor, color, placeholderColor, initialCSSText, cssText, contentCSSText, caretColor} = {},
       html,
@@ -167,10 +169,18 @@ export default class RichTextEditor extends Component {
           console.log('FROM EDIT:', ...data);
           break;
         case messages.SELECTION_CHANGE:
-          const items = message.data;
-          that.selectionChangeListeners.map(listener => {
-            listener(items);
-          });
+          // fire the cursor context listener with data from the message
+          console.log('SELECTION_CHANGE', data);
+          if (data.type === 'cursor') {
+            that.cursorContextListeners.map(listener => {
+              listener(data);
+            })
+          }
+          else {
+            that.selectionChangeListeners.map(listener => {
+              listener(data);
+            });
+          }
           break;
         case messages.CONTENT_FOCUSED:
           that._focus = true;
@@ -317,6 +327,10 @@ export default class RichTextEditor extends Component {
 
   registerToolbar(listener) {
     this.selectionChangeListeners = [...this.selectionChangeListeners, listener];
+  }
+
+  subscribeToCursorContext(listener) {
+    this.cursorContextListeners = [...this.cursorContextListeners, listener];
   }
 
   /**

--- a/src/editor.js
+++ b/src/editor.js
@@ -443,10 +443,8 @@ function createHTML(options = {}) {
         }
 
         /**
-         * Inserts MARKER_START and MARKER_END at the selection boundaries in the DOM.
-         * If the selection is non-collapsed, the START marker goes at the "start" boundary, and the END marker goes at the "end" boundary.
-         * If the selection is collapsed (just a caret), both markers get inserted at the same spot
-         * Note: After this insertion, we remove the active selection ranges, so the user won't potentially see a highlight of these tokens.
+         * Inserts MARKER_START and MARKER_END at the selection boundaries in the editor content to track cursor position.
+         * Note: Prior to insertion, we remove the active selection ranges, so the user won't potentially see a highlight of these tokens.
          */
         function insertMarkerTokens(element) {
             const selection = window.getSelection();
@@ -455,9 +453,11 @@ function createHTML(options = {}) {
             const range = selection.getRangeAt(0);
             selection.removeAllRanges();
 
+            // If the range is collapsed, insert both markers at the cursor position.
             if (range.collapsed) {
                 range.insertNode(document.createTextNode(MARKER_END));
                 range.insertNode(document.createTextNode(MARKER_START));
+            // If the range is not collapsed, insert markers at the start and end boundaries.
             } else {
                 // Clone the original range so we can manipulate each boundary independently.
                 const startRange = range.cloneRange();

--- a/src/editor.js
+++ b/src/editor.js
@@ -602,82 +602,81 @@ function createHTML(options = {}) {
             }
                 
             const selection = window.getSelection();
+            const selectedText = selection.toString();
             // if no cursor in the document, return
             if (!selection.rangeCount) return;
 
             let range = selection.getRangeAt(0);
             let anchorNode = range.startContainer;
-            console.log('anchorNode', anchorNode, anchorNode.nodeName, anchorNode===editorContent);
-
-            // Edge cases for cursor placement
-            // if anchor node happens to be the editor, we're outside of the bounds of the rest of the content which can lead to unexpected behavior
-            if (anchorNode === editorContent) {
-                // place the range in the last child of the editor
-                console.log('anchorNode.lastChild', anchorNode.lastChild, anchorNode.lastChild?.nodeName);
-                if (anchorNode.lastChild && anchorNode.lastChild.nodeName === 'DIV') {
-                    let newPlacement = anchorNode.lastChild;
-                    console.log('anchorNode.lastChild.lastChild', anchorNode.lastChild.lastChild, anchorNode.lastChild.lastChild.nodeName);
-                    if (newPlacement.lastChild.nodeType === Node.TEXT_NODE) {
-                    console.log('found text node');
-                        newPlacement = newPlacement.lastChild;
-                    }                    
-                    const newRange = document.createRange();
-                    newRange.selectNodeContents(newPlacement);
-                    newRange.collapse(false);
-                    selection.removeAllRanges();
-                    selection.addRange(newRange);            
-                }
-            }
-
-            // if the anchor node parent happens to be a span, we're in the middle of a markdown tag, let's get back to the parent div if we're adjacent to the tag
-            if (anchorNode.parentNode.nodeName === 'SPAN' && anchorNode.parentNode.className === 'markdown-tag') {
-                console.log('anchorNode.parentNode', anchorNode.parentNode, anchorNode.parentNode.nodeName);
-                console.log('anchorNode parent sibling', anchorNode.parentNode.previousSibling?.nodeName, anchorNode.parentNode.nextSibling?.nodeName);
-                let newPlacement = anchorNode.parentNode;
-                // if the previous sibling is a styled text node and the cursor is at the start, we want to place the cursor at the end of the text node
-                if (anchorNode.parentNode.previousSibling && ALLOWED_NODE_NAME_REGEX.test(anchorNode.parentNode.previousSibling.nodeName) && range.startOffset === 0) {
-                    console.log('found previous sibling');
-                    // place the range in the previous sibling
-                     let newPlacement = anchorNode.parentNode.previousSibling;
-                    console.log('newPlacement.lastChild', newPlacement.lastChild, newPlacement.lastChild.nodeName);
-                    if (newPlacement.lastChild.nodeType === Node.TEXT_NODE) {
-                        console.log('found text node');
-                        newPlacement = newPlacement.lastChild;
-                    }
-                    const newRange = document.createRange();
-                    newRange.selectNodeContents(newPlacement);
-                    newRange.collapse(false);
-                    selection.removeAllRanges();
-                    selection.addRange(newRange);
-                } else if (anchorNode.parentNode.nextSibling && ALLOWED_NODE_NAME_REGEX.test(anchorNode.parentNode.nextSibling.nodeName) && range.startOffset === anchorNode.parentNode.textContent.length) { 
-                    console.log('found next sibling');
-                    // place the range in the previous sibling
-                     let newPlacement = anchorNode.parentNode.nextSibling;
-                    console.log('newPlacement.firstChild', newPlacement.firstChild, newPlacement.firstChild.nodeName);
-                    if (newPlacement.firstChild.nodeType === Node.TEXT_NODE) {
-                        console.log('found text node');
-                         newPlacement = newPlacement.firstChild;
-
-                    }       
-                    const newRange = document.createRange();
-                    newRange.setStart(newPlacement, 0);
-                    newRange.setEnd(newPlacement, 0);
-                    selection.removeAllRanges();
-                    selection.addRange(newRange);
-            
-                }
-            } 
-
-            // Get the text before and after the selection for detecting if the markdown syntax is already present
             let before = "";
             let after = "";
-            if (selection.rangeCount > 0) {
-                console.log('no selection, getting surrounding text');
+            console.log('anchorNode', anchorNode, anchorNode.nodeName, anchorNode===editorContent);
+
+            if (selection.isCollapsed) {
+                // Edge cases for cursor placement
+                // if anchor node happens to be the editor, we're outside of the bounds of the rest of the content which can lead to unexpected behavior
+                if (anchorNode === editorContent) {
+                    // place the range in the last child of the editor
+                    console.log('anchorNode.lastChild', anchorNode.lastChild, anchorNode.lastChild?.nodeName);
+                    if (anchorNode.lastChild && anchorNode.lastChild.nodeName === 'DIV') {
+                        let newPlacement = anchorNode.lastChild;
+                        console.log('anchorNode.lastChild.lastChild', anchorNode.lastChild.lastChild, anchorNode.lastChild.lastChild.nodeName);
+                        if (newPlacement.lastChild.nodeType === Node.TEXT_NODE) {
+                        console.log('found text node');
+                            newPlacement = newPlacement.lastChild;
+                        }                    
+                        const newRange = document.createRange();
+                        newRange.selectNodeContents(newPlacement);
+                        newRange.collapse(false);
+                        selection.removeAllRanges();
+                        selection.addRange(newRange);            
+                    }
+                }
+
+                // if the anchor node parent happens to be a span, we're in the middle of a markdown tag, let's get back to the parent div if we're adjacent to the tag
+                if (anchorNode.parentNode.nodeName === 'SPAN' && anchorNode.parentNode.className === 'markdown-tag') {
+                    console.log('anchorNode.parentNode', anchorNode.parentNode, anchorNode.parentNode.nodeName);
+                    console.log('anchorNode parent sibling', anchorNode.parentNode.previousSibling?.nodeName, anchorNode.parentNode.nextSibling?.nodeName);
+                    let newPlacement = anchorNode.parentNode;
+                    // if the previous sibling is a styled text node and the cursor is at the start, we want to place the cursor at the end of the text node
+                    if (anchorNode.parentNode.previousSibling && ALLOWED_NODE_NAME_REGEX.test(anchorNode.parentNode.previousSibling.nodeName) && range.startOffset === 0) {
+                        console.log('found previous sibling');
+                        // place the range in the previous sibling
+                        let newPlacement = anchorNode.parentNode.previousSibling;
+                        console.log('newPlacement.lastChild', newPlacement.lastChild, newPlacement.lastChild.nodeName);
+                        if (newPlacement.lastChild.nodeType === Node.TEXT_NODE) {
+                            console.log('found text node');
+                            newPlacement = newPlacement.lastChild;
+                        }
+                        const newRange = document.createRange();
+                        newRange.selectNodeContents(newPlacement);
+                        newRange.collapse(false);
+                        selection.removeAllRanges();
+                        selection.addRange(newRange);
+                    } else if (anchorNode.parentNode.nextSibling && ALLOWED_NODE_NAME_REGEX.test(anchorNode.parentNode.nextSibling.nodeName) && range.startOffset === anchorNode.parentNode.textContent.length) { 
+                        console.log('found next sibling');
+                        // place the range in the previous sibling
+                        let newPlacement = anchorNode.parentNode.nextSibling;
+                        console.log('newPlacement.firstChild', newPlacement.firstChild, newPlacement.firstChild.nodeName);
+                        if (newPlacement.firstChild.nodeType === Node.TEXT_NODE) {
+                            console.log('found text node');
+                            newPlacement = newPlacement.firstChild;
+
+                        }       
+                        const newRange = document.createRange();
+                        newRange.setStart(newPlacement, 0);
+                        newRange.setEnd(newPlacement, 0);
+                        selection.removeAllRanges();
+                        selection.addRange(newRange);
+                
+                    }
+                } 
+                // With a collapsed range, detect the text before and after the selection to see if the markdown syntax is already present
                 const surroundingText = getSurroundingTextFromSelection();
                 before = surroundingText.before;
                 after = surroundingText.after;
             }
-                
+
             // console.log('before', before, before.length, 'after', after, after.length, 'selectedText', selectedText);
 
             // insert selection tokens to track the selection position through parsing.
@@ -1190,6 +1189,13 @@ function createHTML(options = {}) {
                     }
                 }
             };
+            document.addEventListener('selectionchange', () => {
+                console.log('selectionchange');
+                // debounce this function to prevent multiple calls
+                // if range parent is bold or italic we want to show the button as active
+                // we could broadcast it to the component via content change, or write our own handler
+                // let's hijack the selection change listener
+            });
             document.addEventListener("message", message , false);
             window.addEventListener("message", message , false);
             document.addEventListener('mouseup', function (event) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -342,9 +342,10 @@ function createHTML(options = {}) {
         /**
         * String parsing function to add markdown elements to the editor content
         */ 
+        const MARKDOWN_SYNTAX_REGEX =  /(\\*\\*\\*|___)(?!\\1)(.*?)\\1|(\\*\\*|__)(?!\\3)(.*?)\\3|(\\*|_)(?!\\5)(.*?)\\5|(~~)(?!\\7)(.*?)\\7/g;
         function addMarkdownElements(element) {
             return element.innerHTML.replace(
-                /(\\*\\*\\*|___)(?!\\1)(.*?)\\1|(\\*\\*|__)(?!\\3)(.*?)\\3|(\\*|_)(?!\\5)(.*?)\\5|(~~)(?!\\7)(.*?)\\7/g,
+                MARKDOWN_SYNTAX_REGEX,
                 function(match, boldItalic, biContent, bold, bContent, italic, iContent, strike, sContent) {
                     if (boldItalic && biContent && !isMatchOnSelectionMarkers(biContent)) {
                         return applyMarkdownSyntax(boldItalic) +
@@ -522,7 +523,7 @@ function createHTML(options = {}) {
             // If we found only one or neither, return null
             return null;
         }
-
+        
         function getSurroundingTextFromSelection() {
             const selection = window.getSelection();
             if (!selection || selection.rangeCount === 0) {
@@ -668,8 +669,16 @@ function createHTML(options = {}) {
             } 
 
             // Get the text before and after the selection for detecting if the markdown syntax is already present
-            const { before, selectedText, after } = getSurroundingTextFromSelection();
-            console.log('before', before, before.length, 'after', after, after.length, 'selectedText', selectedText);
+            let before = "";
+            let after = "";
+            if (selection.rangeCount > 0) {
+                console.log('no selection, getting surrounding text');
+                const surroundingText = getSurroundingTextFromSelection();
+                before = surroundingText.before;
+                after = surroundingText.after;
+            }
+                
+            // console.log('before', before, before.length, 'after', after, after.length, 'selectedText', selectedText);
 
             // insert selection tokens to track the selection position through parsing.
             insertMarkerTokens();
@@ -710,7 +719,7 @@ function createHTML(options = {}) {
             editorContent.innerHTML = updatedText;
 
             // Parse string to add back markdown syntax
-            console.log('parseMarkdown start', editorContent.innerHTML, selectedText, range.startContainer.textContent);
+            console.log('parseMarkdown start', editorContent.innerHTML, range.startContainer.textContent);
             const parsed = addMarkdownElements(editorContent);
             console.log('parseMarkdown done', parsed);
             editorContent.innerHTML = parsed;

--- a/src/editor.js
+++ b/src/editor.js
@@ -519,11 +519,9 @@ function createHTML(options = {}) {
 
             // Look forward from the end of the selection
             for (let i = endOffset; i < text.length; i++) {
-                console.log('text[i]', text[i]);
                 if (isStopCharacter(text[i])) {
                     break;
                 }
-                console.log('textAfterCursor', textAfterCursor);
                 textAfterCursor += text[i];
             }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -279,8 +279,9 @@ function createHTML(options = {}) {
          * Unique markers for selection boundaries. These are used to track the cursor position through parsing.
          * These string based boundaries are useful for persisting heavy dom manipulations and string based updates.
          */
-        const MARKER_START = "@@----SELECTION-START----@@";
-        const MARKER_END = "@@----SELECTION-END----@@";
+        const timestamp = Date.now();
+        const MARKER_START = "@@----SELECTION-START-" + timestamp + "----@@";
+        const MARKER_END = "@@----SELECTION-END-" + timestamp + "----@@";
 
         /**
          * Inserts MARKER_START and MARKER_END at the selection boundaries in the editor content to track cursor position.
@@ -1209,23 +1210,24 @@ function createHTML(options = {}) {
                 // basic cursor data - determine if current range is in a bold or italic block
                 // this can be expanded on to include detection for mention and emoji actions
                 const range = window.getSelection().getRangeAt(0);
-                if (!range) return;
-
-                // update selection boundaries to ensure the cursor is in the right place
-                fixSelectionBoundaries();
 
                 const cursorData = { type: 'cursor', decorators: { bold: false, italic: false, strikeThrough: false } };
-                const isBold = determineSelectionDecorator(range, ALLOWED_SYNTAX_TAGS.bold);
-                if (isBold) {
-                   cursorData.decorators.bold = true;
-                }       
-                const isItalic = determineSelectionDecorator(range, ALLOWED_SYNTAX_TAGS.italic);
-                if (isItalic) {
-                   cursorData.decorators.italic = true;
-                }
-                const isStrikeThrough = determineSelectionDecorator(range, ALLOWED_SYNTAX_TAGS.strikeThrough);
-                if (isStrikeThrough) {
-                   cursorData.decorators.strikeThrough = true;
+                if (range) {
+                    // update selection boundaries to ensure the cursor is in the right place
+                    fixSelectionBoundaries();
+
+                    const isBold = determineSelectionDecorator(range, ALLOWED_SYNTAX_TAGS.bold);
+                    if (isBold) {
+                    cursorData.decorators.bold = true;
+                    }       
+                    const isItalic = determineSelectionDecorator(range, ALLOWED_SYNTAX_TAGS.italic);
+                    if (isItalic) {
+                    cursorData.decorators.italic = true;
+                    }
+                    const isStrikeThrough = determineSelectionDecorator(range, ALLOWED_SYNTAX_TAGS.strikeThrough);
+                    if (isStrikeThrough) {
+                    cursorData.decorators.strikeThrough = true;
+                    }
                 }
   
                 postAction({type: 'SELECTION_CHANGE', data: cursorData });


### PR DESCRIPTION
# Overview

This PR includes:
 - Enabling markdown toggling with toggleMarkdown. This function inserts the markdown syntax of choice into the html, either around the selection or around the word the cursor is in with look ahead and look behind.
 - Updating the selection change handler to send information out about the cursor's position. Right now this just includes if the cursor is in a bold, italic, or strikethrough syntax. I created a listener function in Rich Editor and types to support this functionality in TS.
 - Creating a fixSelectionBoundaries handler to update the cursor position if it falls into an undesirable place on user selection
 - Enhances selection tracking with marker tokens. I updated the original markdown parsing function to use this as well
 - Refactors various functions to improve re-usability across code