### PR TITLE
Spencer/mob 200 inline styled mentions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -232,7 +232,7 @@ export type IconRecord = {
 };
 export type SelectionChangeListener = (items: (string | {type: string; value: string})[]) => void;
 
-export type CursorContext =  {  type: 'cursor'; decorators: { bold: boolean; italic: boolean; strikeThrough: boolean } }
+export type CursorContext =  {  type: 'cursor'; decorators: { bold: boolean; italic: boolean; strikeThrough: boolean }; channelMention: string; userMention: string; };
 export type CursorContextListener = (items: CursorContext) => void;
 export declare class RichEditor extends React.Component<RichEditorProps> {
   // Public API

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -168,7 +168,6 @@ export default class RichTextEditor extends Component {
         case messages.LOG:
           break;
         case messages.SELECTION_CHANGE:
-          console.log('SELECTION_CHANGE', data);
           // fire the cursor context listener with data from the message
           if (data.type === 'cursor') {
             that.cursorContextListeners.map(listener => {

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -168,6 +168,7 @@ export default class RichTextEditor extends Component {
         case messages.LOG:
           break;
         case messages.SELECTION_CHANGE:
+          console.log('SELECTION_CHANGE', data);
           // fire the cursor context listener with data from the message
           if (data.type === 'cursor') {
             that.cursorContextListeners.map(listener => {

--- a/src/editor.js
+++ b/src/editor.js
@@ -1490,11 +1490,9 @@ function createHTML(options = {}) {
                 }
             };
             document.addEventListener('selectionchange', () => {
-                console.log('selection change')
                 // basic cursor data - determine if current range is in a bold or italic block
-                // this can be expanded on to include detection for mention and emoji actions
+                // and check for mention characters
                 const range = window.getSelection().getRangeAt(0);
-                console.log('range', range);
                 const cursorData = { type: 'cursor', decorators: { bold: false, italic: false, strikeThrough: false }, channelMention: '', userMention: '' };
                 if (range) {
                     // update selection boundaries to ensure the cursor is in the right place
@@ -1513,11 +1511,8 @@ function createHTML(options = {}) {
                         cursorData.decorators.strikeThrough = true;
                     }
                     if (!isBold && !isItalic && !isStrikeThrough) {
-                        console.log('check for mention')
-
                         cursorData.channelMention = checkForMention('#');
                         cursorData.userMention = checkForMention('@');
-                        // detect if we want to do a mention or emoji action
                     }
                 }
   

--- a/src/editor.js
+++ b/src/editor.js
@@ -1032,14 +1032,14 @@ function createHTML(options = {}) {
             const container = range.startContainer;
             const offset = range.startOffset;
 
-            // Create a text node with " @ " using visible space characters
-            const atSymbolNode = document.createTextNode("\u00A0@\u00A0");
+            // Create a text node with "@"
+            const atSymbolNode = document.createTextNode("@");
 
             // Insert the text node at the current selection
             range.insertNode(atSymbolNode);
 
             // Move the cursor right after the "@" character
-            range.setStart(atSymbolNode, 2);
+            range.setStart(atSymbolNode, 1);
             range.collapse(true);
 
             // Clear the current selection and set the new range

--- a/src/editor.js
+++ b/src/editor.js
@@ -641,11 +641,17 @@ function createHTML(options = {}) {
             // Update the editor content
             tempDiv.innerHTML = updatedText;
 
+             // insert mention markers
+            const { updatedHtml, mentionPlaceholders } = insertMentionMarkers(tempDiv);
+
             // Parse string to add back markdown syntax
-            const parsed = addMarkdownElements(tempDiv);
+            const parsedHTML = addMarkdownElements(updatedHtml); 
+
+            // Restore mention spans
+            const finalHTML = restoreMentionSpans(parsedHTML, mentionPlaceholders);
 
             // Update the editor content
-            editorContent.innerHTML = parsed;
+            editorContent.innerHTML = finalHTML;
         
             // Determine marker locations in the new content
             const markerPositions = findMarkerTokensAndPlaceRanges(editorContent);


### PR DESCRIPTION
# Overview
This PR adds mention parsing and display support to the rich text editor.

It includes:
- Detecting when a mention search is active at the current cursor position. We do so by performing a search in the word at the cursor's current position for our mention characters (either @ or #)
- Returning the mention search to the UI via the cursor context object. This is used to present the mention popup window to the user where they can view search results.
- Inserting mentions into the editor controlled by the outer UI events (such as pressing on a mention from search).
- Initiating mention search with a control to insert an "@".
- Handling mentions through live markdown parsing with token markers.
- Cleaning up invalid mentions on inline edits.