### PR TITLE
Add spoiler markdown support (`||text||`)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -254,7 +254,7 @@ export type SelectionChangeListener = (items: (string | {type: string; value: st
 
 export type CursorContext =  {
    type: 'cursor';
-   decorators: { bold: boolean; italic: boolean; strikeThrough: boolean };
+   decorators: { bold: boolean; italic: boolean; strikeThrough: boolean; spoiler: boolean };
    channelMention: string;
    userMention: string;
    emojiShortcodeMention: string;

--- a/src/editor.js
+++ b/src/editor.js
@@ -15,6 +15,7 @@ function getContentCSS() {
         hr{display: block;height: 0; border: 0;border-top: 1px solid #ccc; margin: 15px 0; padding: 0;}
         pre{padding: 10px 5px 10px 10px;margin: 15px 0;display: block;line-height: 18px;background: #F0F0F0;border-radius: 6px;font-size: 13px; font-family: 'monaco', 'Consolas', "Liberation Mono", Courier, monospace; word-break: break-all; word-wrap: break-word;overflow-x: auto;}
         pre code {display: block;font-size: inherit;white-space: pre-wrap;color: inherit;}
+        .spoiler {background-color: rgba(80, 80, 90, 0.45); border-radius: 3px; padding: 0 2px;}
     </style>
     `;
 }
@@ -557,10 +558,10 @@ function createHTML(options = {}) {
         /**
         * String parsing function to add markdown elements to the editor content
         */
-        const TEXT_DECORATION_REGEX =  /(\\*\\*\\*|___)(?!\\1)(.*?)\\1|(\\*\\*|__)(?!\\3)(.*?)\\3|(\\*|_)(?!\\5)(.*?)\\5|(~~)(?!\\7)(.*?)\\7/g;
+        const TEXT_DECORATION_REGEX =  /(\\*\\*\\*|___)(?!\\1)(.*?)\\1|(\\*\\*|__)(?!\\3)(.*?)\\3|(\\*|_)(?!\\5)(.*?)\\5|(~~)(?!\\7)(.*?)\\7|(\\|\\|)(?!\\9)(.*?)\\9/g;
         function parseTextDecorationFromMarkdown(html) {
             return html.replace(TEXT_DECORATION_REGEX, function(
-                match, boldItalic, biContent, bold, bContent, italic, iContent, strike, sContent
+                match, boldItalic, biContent, bold, bContent, italic, iContent, strike, sContent, spoiler, spContent
             ) {
                 if (boldItalic && biContent && !isMatchOnSelectionMarkers(biContent) && !matchContainsNewline(biContent)) {
                 return applyMarkdownSyntax(boldItalic) +
@@ -578,6 +579,10 @@ function createHTML(options = {}) {
                 return applyMarkdownSyntax(strike) +
                     '<s>' + sContent + '</s>' +
                     applyMarkdownSyntax(strike);
+                } else if (spoiler && spContent && !isMatchOnSelectionMarkers(spContent) && !matchContainsNewline(spContent)) {
+                return applyMarkdownSyntax(spoiler) +
+                    '<span class="spoiler">' + spContent + '</span>' +
+                    applyMarkdownSyntax(spoiler);
                 }
                 return match;
             });
@@ -668,7 +673,7 @@ function createHTML(options = {}) {
 
             // Helper function to check if a character should stop the traversal
             function isStopCharacter(char) {
-                return !char.trim() || char === "\\s+" || char === "*" || char === "\`" || char === "~";
+                return !char.trim() || char === "\\s+" || char === "*" || char === "\`" || char === "~" || char === "|";
             }
 
             // Look backward from the start of the selection
@@ -695,7 +700,8 @@ function createHTML(options = {}) {
             italic: '*',
             bold: '**',
             strikeThrough: '~~',
-            code: '\`'
+            code: '\`',
+            spoiler: '||'
         };
 
         /**
@@ -927,6 +933,10 @@ function createHTML(options = {}) {
             if (parent.nodeName === 'I' && nodeName === 'B') {
                 parent = parent.parentNode;
             }
+            // spoiler is a class-marked span, not a dedicated tag
+            if (nodeName === 'SPOILER') {
+                return parent.nodeName === 'SPAN' && parent.classList && parent.classList.contains('spoiler');
+            }
             return parent.nodeName === nodeName;
         };
 
@@ -935,6 +945,7 @@ function createHTML(options = {}) {
             italic: 'I',
             bold: 'B',
             strikeThrough: 'S',
+            spoiler: 'SPOILER',
         };
 
         // Track the last content value
@@ -2298,7 +2309,7 @@ function createHTML(options = {}) {
                 // basic cursor data - determine if current range is in a bold or italic block
                 // and check for mention characters
                 const range = window.getSelection().getRangeAt(0);
-                const cursorData = { type: 'cursor', decorators: { bold: false, italic: false, strikeThrough: false }, channelMention: '', userMention: '', emojiShortcodeMention: '' };
+                const cursorData = { type: 'cursor', decorators: { bold: false, italic: false, strikeThrough: false, spoiler: false }, channelMention: '', userMention: '', emojiShortcodeMention: '' };
                 if (range) {
 
                     // update selection boundaries to ensure the cursor is in the right place
@@ -2316,7 +2327,11 @@ function createHTML(options = {}) {
                     if (isStrikeThrough) {
                         cursorData.decorators.strikeThrough = true;
                     }
-                    if (!isBold && !isItalic && !isStrikeThrough) {
+                    const isSpoiler = determineSelectionDecorator(range, ALLOWED_SYNTAX_TAGS.spoiler);
+                    if (isSpoiler) {
+                        cursorData.decorators.spoiler = true;
+                    }
+                    if (!isBold && !isItalic && !isStrikeThrough && !isSpoiler) {
                         const insertionMarker = checkForInsertionMarkerAroundCursor();
                         if (insertionMarker) {
                             cursorData[markerToFieldMap[insertionMarker.character]] = insertionMarker.mention;


### PR DESCRIPTION
## Summary

Adds a `spoiler` markdown type to `toggleMarkdown`, mirroring how bold / italic / strikeThrough work today but wrapping content in `<span class="spoiler">` rather than a semantic tag. The cursor context now reports `decorators.spoiler` so toolbars can light up the active state. Pairs with the mobile PR that adds the toolbar button.

### Changes

- `TEXT_DECORATION_REGEX` extended with a `(\|\|)(?!\9)(.*?)\9` branch; `parseTextDecorationFromMarkdown` wraps the inner content in `<span class="spoiler">…</span>` flanked by the existing `markdown-tag` markers, same shape as the other decorations.
- `MARKDOWN_SYNTAX.spoiler = '||'` so `sendAction('toggleMarkdown', 'result', 'spoiler')` resolves.
- `|` added to `isStopCharacter` so collapsed-cursor toggling treats pipes as boundaries (matches how `*`, `~`, backtick already behave).
- `determineSelectionDecorator` learns the `SPOILER` pseudo-tag — needed because the wrap uses a class, not a dedicated HTML tag, so the existing `nodeName === ` comparison wouldn't match.
- Default `.spoiler` rule in `getContentCSS` (semi-transparent dark fill) so wrapped text is visually marked in both light and dark editors. Consumers can override via `editorStyle.contentCSSText`.
- `CursorContext.decorators` type extended with `spoiler: boolean`.

### Notes

- The class-based span approach keeps the parser symmetric with existing decorators while side-stepping the lack of a dedicated HTML element for spoilers.
- Nesting precedence falls out of the regex alternation order: outer `**||x||**` is parsed as bold-wrapping-text, while `||**x**||` is spoiler-wrapping-bold. Same way `**~~x~~**` works today.

## Test plan

- [ ] In a consumer app, type `||hello||` → renders the dimmed `.spoiler` background between visible `||` markers.
- [ ] Place cursor inside a spoiler and tap a toolbar button bound to `toggleMarkdown('spoiler')` → strips the `||...||`.
- [ ] Select plain text, toggle spoiler → wraps with `||...||`.
- [ ] Cursor moves into a spoiler region → `subscribeToCursorContext` fires with `decorators.spoiler === true`; out → `false`.
- [ ] Mixed cases: `**||x||**`, `||**x**||`, `||x|y||` (single pipe inside) all parse without breaking surrounding decorations.
- [ ] Other markdown (bold/italic/strike/code) toggles still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)