### PR TITLE
Trigger live re-parse when typing inside spoiler markers

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1487,7 +1487,7 @@ function createHTML(options = {}) {
           return false;
         }
 
-        const pairRegex = /(\\*{1,3}|_{1,3}|~{2})(?=\\S)([\\s\\S]*?\\S)\\1/g;
+        const pairRegex = /(\\*{1,3}|_{1,3}|~{2}|\\|{2})(?=\\S)([\\s\\S]*?\\S)\\1/g;
         let prevPairCount = 0;
         /**
          * Counts the number of balanced markdown pairs in the content.
@@ -1504,7 +1504,7 @@ function createHTML(options = {}) {
          */
         function shouldParseMarkdown(inputType, data) {
           // typed a marker
-          if (inputType === 'insertText' && /[\\*_~]/.test(data)) return true;
+          if (inputType === 'insertText' && /[\\*_~|]/.test(data)) return true;
           // deleted content
           if (inputType === 'deleteContentBackward' ||
               inputType === 'deleteContentForward') {


### PR DESCRIPTION
## Summary

Follow-up to #22. After toggling spoiler markers in the editor, typing inside them didn't activate the syntax highlight.

### Repro

1. Type `test ` in the editor.
2. Tap the spoiler toolbar button → editor inserts `||<cursor>||`.
3. Type `spoiler` between the markers.
4. **Expected**: `spoiler` renders inside a `.spoiler` span as soon as the closing `||` pair is satisfied. **Actual**: stays plain text — no highlight.

### Cause

`shouldParseMarkdown` decides whether each input event re-runs `parseMarkdown`. Two predicates that govern it both ignored `|`:

- The "typed a marker" character class was `[*_~]`, so typing `|` (or any letter inside an existing `||...||`) returned false.
- `pairRegex` (used by `countMarkdownPairs` to detect when balanced-pair count changes) was `(\*{1,3}|_{1,3}|~{2})`, so completing a `||x||` pair didn't move the count.

With both predicates blind to pipes, the only paths that would re-parse were deletions or the cursor already being inside a `markdown-tag` span — neither of which fires while you're typing into a freshly-toggled empty spoiler (the markers are still bare text, not yet wrapped).

### Fix

- Add `|` to the trigger character class.
- Add `\|{2}` to `pairRegex` so spoiler pair completions move the count too.

Both are minimal additions to the existing predicates; bold/italic/strike behavior is unchanged.

## Test plan

- [ ] Repro above now highlights `||spoiler||` as soon as the closing pair is typed.
- [ ] Typing `||hello||` from scratch (no toggle) also highlights.
- [ ] Bold/italic/strike still toggle and re-parse as before — no regression on the existing decorators.
- [ ] Backspacing across a spoiler boundary still re-parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)